### PR TITLE
Fixed link to dataset, and column-id

### DIFF
--- a/code/index.html
+++ b/code/index.html
@@ -151,7 +151,7 @@
             </table>
           </td>
           <td>
-            <table id="column35">
+            <table id="column15">
               <thead>
                 <tr>
                   <th colspan="4">Cameras 3 &amp; 5</th>

--- a/code/index.html
+++ b/code/index.html
@@ -110,7 +110,7 @@
   <div id="mapid"></div>
   <div id="source">
     source:
-    <a href="https://data.overheid.nl/data/dataset/camera-s">https://data.overheid.nl/data/dataset/camera-s</a>
+    <a href="https://data.overheid.nl/dataset/utrecht-cameraregister-utrecht">https://data.overheid.nl/dataset/utrecht-cameraregister-utrecht</a>
   </div>
   <main>
     <table id="cameraTableContainer">
@@ -151,7 +151,7 @@
             </table>
           </td>
           <td>
-            <table id="column15">
+            <table id="column35">
               <thead>
                 <tr>
                   <th colspan="4">Cameras 3 &amp; 5</th>


### PR DESCRIPTION
1. De link naar de camera-dataset geeft - inmiddels - een 403, dit is (volgens mij) de juiste link. 
2. De column (table) met camera-numbers deelbaar door 3 én 5 had een verwarrende id 😄